### PR TITLE
Create custom styling for React Calendar

### DIFF
--- a/src/app/components/Calendar/Calendar.module.css
+++ b/src/app/components/Calendar/Calendar.module.css
@@ -1,3 +1,0 @@
-.cal {
-  color: green;
-}

--- a/src/app/components/Calendar/Calendar.tsx
+++ b/src/app/components/Calendar/Calendar.tsx
@@ -11,14 +11,14 @@ export default function ReactCalendar(): JSX.Element {
 import React, { useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
-import styles from './Calendar.module.css';
+import './CustomCalendar.css';
 
 export default function ReactCalendar(): JSX.Element {
   const [value, onChange] = useState(new Date());
 
   return (
     <div>
-      <Calendar onChange={onChange} value={value} className={styles.cal} />
+      <Calendar onChange={onChange} value={value} />
     </div>
   );
 }

--- a/src/app/components/Calendar/CustomCalendar.css
+++ b/src/app/components/Calendar/CustomCalendar.css
@@ -100,3 +100,27 @@
   background: #f9f2ff;
   border-radius: 50%;
 }
+
+/* Jahresübersicht mit Monaten */
+.react-calendar__year-view__months__month {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+  color: #8312a5;
+  font-size: 0.8rem;
+}
+
+/* Dekadenübersicht mit Jahren */
+.react-calendar__decade-view__years__year {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+  color: #8312a5;
+  font-size: 0.8rem;
+}
+
+/* Jahrhundertübersicht mit Dekaden */
+.react-calendar__century-view__decades__decade {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+  color: #8312a5;
+  font-size: 0.8rem;
+}

--- a/src/app/components/Calendar/CustomCalendar.css
+++ b/src/app/components/Calendar/CustomCalendar.css
@@ -1,7 +1,21 @@
+.react-calendar {
+  width: 320px;
+  max-width: 100%;
+  background: white;
+  border: none;
+}
+
+/* Adapt Nav Bar // Is there a way to overwrite the inline style of the navigation that sets display=flex to grid, other that using !important? */
+.react-calendar__navigation {
+  display: grid !important;
+  grid-template-columns: 1% 9% 80% 9% 1%;
+  justify-items: center;
+}
+
 /* Month */
 .react-calendar__navigation__label__labelText--from {
   color: #f9f2ff;
-  font-size: 2.5rem;
+  font-size: 2rem;
 }
 
 /* Arrow to next month */
@@ -31,11 +45,15 @@
 /* Mo-So */
 .react-calendar__month-view__weekdays {
   font-family: var(--font-family-primary);
-  font-weight: var(--font-weight-light);
+  font-weight: 300;
   color: #8312a5;
   font-size: 0.9rem;
   text-align: center;
   text-transform: none;
+}
+
+/* einzelner Tag // How to remove dotted underline below Mo, Di Mi, Do, Fr, Sa, So? Text-decoration: none does not seem to work. */
+.react-calendar__month-view__weekdays__weekday {
   text-decoration: none;
 }
 
@@ -63,28 +81,22 @@
   border-radius: 50%;
 }
 
-.react-calendar__tile--now:enabled:focus {
+/* beim anklicken */
+.react-calendar__tile--now:enabled:focus,
+.react-calendar__tile--now:enabled:hover {
   background: #ffda7a;
   border-radius: 50%;
 }
 
 /* Tile active: die Kachel, die angeklickt wird */
 .react-calendar__tile--active {
-  background: #ffda7a;
+  background: #f9f2ff;
   border-radius: 50%;
 }
 
-.react-calendar__tile--active:enabled:focus {
-  background: transparent;
+/* beim anklicken */
+.react-calendar__tile--active:enabled:focus,
+.react-calendar__tile--active:enabled:hover {
+  background: #f9f2ff;
   border-radius: 50%;
-  border: solid 0.1rem #ffda7a;
 }
-
-/*
-.react-calendar--selectRange , .react-calendar__tile--now:enabled:focus
-.react-calendar__tile--now:enabled:hover,
-.react-calendar__tile--active:enabled:hover,
-.react-calendar__tile:enabled:hover {
-  border: solid #ffda7a 0.1rem;
-}
-*/

--- a/src/app/components/Calendar/CustomCalendar.css
+++ b/src/app/components/Calendar/CustomCalendar.css
@@ -1,7 +1,3 @@
-.react-calendar__month-view__days__day--weekend {
-  color: goldenrod;
-}
-
 /* Month */
 .react-calendar__navigation__label__labelText--from {
   color: #f9f2ff;
@@ -28,44 +24,67 @@
 
 /* Remove arrow to same month, previous year */
 .react-calendar__navigation__prev2-button {
-  display: hidden;
+  color: transparent;
   padding: 0;
 }
+
+/* Mo-So */
 .react-calendar__month-view__weekdays {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-light);
+  color: #8312a5;
+  font-size: 0.9rem;
   text-align: center;
   text-transform: none;
-  font-weight: 300;
-  font-size: 0.75em;
-  color: #8312a5;
   text-decoration: none;
 }
-.react-calendar__month-view__weekNumbers {
-  font-weight: 400;
+
+/* Zahlen im Kalender, des jeweiligen Monats */
+.react-calendar__month-view__days__day {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+  color: #8312a5;
   font-size: 1.1rem;
 }
-.react-calendar__month-view__days__day {
-  color: #8312a5;
-}
+
+/* Zahlen im Kalender, des vorherigen und nächsten Monats */
 .react-calendar__month-view__days__day--neighboringMonth {
   color: #9a6691;
 }
+
+/* Einzelne Kachel, wo die Zahlen drin sind */
+.react-calendar__tile {
+  padding: 0.75rem;
+}
+
+/* Tile now: heutige Kachel, wenn nicht angeklickt */
 .react-calendar__tile--now {
   background: #ffda7a;
   border-radius: 50%;
 }
-.react-calendar__tile--now:enabled:hover,
+
 .react-calendar__tile--now:enabled:focus {
+  background: #ffda7a;
   border-radius: 50%;
 }
+
+/* Tile active: die Kachel, die angeklickt wird */
 .react-calendar__tile--active {
   background: #ffda7a;
   border-radius: 50%;
 }
 
-.react-calendar__tile--active:enabled:hover,
 .react-calendar__tile--active:enabled:focus {
-  background: #1087ff;
+  background: transparent;
+  border-radius: 50%;
+  border: solid 0.1rem #ffda7a;
 }
-.react-calendar--selectRange .react-calendar__tile--hover {
-  background-color: #e6e6e6;
+
+/*
+.react-calendar--selectRange , .react-calendar__tile--now:enabled:focus
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile:enabled:hover {
+  border: solid #ffda7a 0.1rem;
 }
+*/

--- a/src/app/components/Calendar/CustomCalendar.css
+++ b/src/app/components/Calendar/CustomCalendar.css
@@ -1,7 +1,6 @@
 .react-calendar {
-  width: 320px;
+  width: 310px;
   max-width: 100%;
-  background: white;
   border: none;
 }
 
@@ -14,20 +13,20 @@
 
 /* Month */
 .react-calendar__navigation__label__labelText--from {
-  color: #f9f2ff;
-  font-size: 2rem;
+  color: var(--color-primary);
+  font-size: var(--font-size-xl);
 }
 
 /* Arrow to next month */
 .react-calendar__navigation__next-button {
-  color: #8312a5;
-  font-size: 2.5rem;
+  color: var(--color-action);
+  font-size: var(--font-size-xl);
 }
 
 /* Arrow to previous month */
 .react-calendar__navigation__prev-button {
-  color: #8312a5;
-  font-size: 2.5rem;
+  color: var(--color-action);
+  font-size: var(--font-size-xl);
 }
 
 /* Remove arrow to same month, next year */
@@ -45,15 +44,14 @@
 /* Mo-So */
 .react-calendar__month-view__weekdays {
   font-family: var(--font-family-primary);
-  font-weight: 300;
-  color: #8312a5;
-  font-size: 0.9rem;
-  text-align: center;
+  font-weight: var(--font-weight-light);
+  color: var(--color-action);
+  font-size: var(--font-size-xs);
   text-transform: none;
 }
 
-/* einzelner Tag // How to remove dotted underline below Mo, Di Mi, Do, Fr, Sa, So? Text-decoration: none does not seem to work. */
-.react-calendar__month-view__weekdays__weekday {
+/* Punkte unter Mo, Di, Mi, etc entfernen mit dem abbr tag */
+abbr {
   text-decoration: none;
 }
 
@@ -61,13 +59,13 @@
 .react-calendar__month-view__days__day {
   font-family: var(--font-family-primary);
   font-weight: var(--font-weight-regular);
-  color: #8312a5;
-  font-size: 1.1rem;
+  color: var(--color-action);
+  font-size: var(--font-size-s);
 }
 
 /* Zahlen im Kalender, des vorherigen und nächsten Monats */
 .react-calendar__month-view__days__day--neighboringMonth {
-  color: #9a6691;
+  color: var(--color-tertiary);
 }
 
 /* Einzelne Kachel, wo die Zahlen drin sind */
@@ -77,27 +75,27 @@
 
 /* Tile now: heutige Kachel, wenn nicht angeklickt */
 .react-calendar__tile--now {
-  background: #ffda7a;
+  background: var(--color-day-highlight);
   border-radius: 50%;
 }
 
 /* beim anklicken */
 .react-calendar__tile--now:enabled:focus,
 .react-calendar__tile--now:enabled:hover {
-  background: #ffda7a;
+  background: var(--color-day-highlight);
   border-radius: 50%;
 }
 
 /* Tile active: die Kachel, die angeklickt wird */
 .react-calendar__tile--active {
-  background: #f9f2ff;
+  background: var(--color-primary);
   border-radius: 50%;
 }
 
 /* beim anklicken */
 .react-calendar__tile--active:enabled:focus,
 .react-calendar__tile--active:enabled:hover {
-  background: #f9f2ff;
+  background: var(--color-primary);
   border-radius: 50%;
 }
 
@@ -105,22 +103,22 @@
 .react-calendar__year-view__months__month {
   font-family: var(--font-family-primary);
   font-weight: var(--font-weight-regular);
-  color: #8312a5;
-  font-size: 0.8rem;
+  color: var(--color-action);
+  font-size: var(--font-size-xs);
 }
 
 /* Dekadenübersicht mit Jahren */
 .react-calendar__decade-view__years__year {
   font-family: var(--font-family-primary);
   font-weight: var(--font-weight-regular);
-  color: #8312a5;
-  font-size: 0.8rem;
+  color: var(--color-action);
+  font-size: var(--font-size-xs);
 }
 
 /* Jahrhundertübersicht mit Dekaden */
 .react-calendar__century-view__decades__decade {
   font-family: var(--font-family-primary);
   font-weight: var(--font-weight-regular);
-  color: #8312a5;
-  font-size: 0.8rem;
+  color: var(--color-action);
+  font-size: var(--font-size-xs);
 }

--- a/src/app/components/Calendar/CustomCalendar.css
+++ b/src/app/components/Calendar/CustomCalendar.css
@@ -1,0 +1,71 @@
+.react-calendar__month-view__days__day--weekend {
+  color: goldenrod;
+}
+
+/* Month */
+.react-calendar__navigation__label__labelText--from {
+  color: #f9f2ff;
+  font-size: 2.5rem;
+}
+
+/* Arrow to next month */
+.react-calendar__navigation__next-button {
+  color: #8312a5;
+  font-size: 2.5rem;
+}
+
+/* Arrow to previous month */
+.react-calendar__navigation__prev-button {
+  color: #8312a5;
+  font-size: 2.5rem;
+}
+
+/* Remove arrow to same month, next year */
+.react-calendar__navigation__next2-button {
+  color: transparent;
+  padding: 0;
+}
+
+/* Remove arrow to same month, previous year */
+.react-calendar__navigation__prev2-button {
+  display: hidden;
+  padding: 0;
+}
+.react-calendar__month-view__weekdays {
+  text-align: center;
+  text-transform: none;
+  font-weight: 300;
+  font-size: 0.75em;
+  color: #8312a5;
+  text-decoration: none;
+}
+.react-calendar__month-view__weekNumbers {
+  font-weight: 400;
+  font-size: 1.1rem;
+}
+.react-calendar__month-view__days__day {
+  color: #8312a5;
+}
+.react-calendar__month-view__days__day--neighboringMonth {
+  color: #9a6691;
+}
+.react-calendar__tile--now {
+  background: #ffda7a;
+  border-radius: 50%;
+}
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  border-radius: 50%;
+}
+.react-calendar__tile--active {
+  background: #ffda7a;
+  border-radius: 50%;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #1087ff;
+}
+.react-calendar--selectRange .react-calendar__tile--hover {
+  background-color: #e6e6e6;
+}

--- a/src/app/components/Typography/Typography.module.css
+++ b/src/app/components/Typography/Typography.module.css
@@ -35,25 +35,25 @@
 }
 
 .xl {
-  font-size: 2.5rem;
+  font-size: var(--font-size-xl);
 }
 
 .l {
-  font-size: 2rem;
+  font-size: var(--font-size-l);
 }
 
 .m {
-  font-size: 1.3rem;
+  font-size: var(--font-size-m);
 }
 
 .s {
-  font-size: 1.1rem;
+  font-size: var(--font-size-s);
 }
 
 .xs {
-  font-size: 0.9rem;
+  font-size: var(--font-size-xs);
 }
 
 .mm {
-  font-size: 1.5rem;
+  font-size: var(--font-size-mm);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,13 @@
 @font-face {
   font-family: 'Lato';
-  src: url('./assets/fonts/Lato-Light.ttf');
   src: url('./assets/fonts/Lato-Regular.ttf');
-  font-weight: 300, 400;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: 'Lato';
+  src: url('./assets/fonts/Lato-Light.ttf');
+  font-weight: 300;
 }
 
 @font-face {
@@ -33,6 +38,12 @@
   --font-family-secondary: 'Permanentmarker', cursive;
   --font-weight-regular: 400;
   --font-weight-light: 300;
+  --font-size-xl: 2.5rem;
+  --font-size-l: 2rem;
+  --font-size-m: 1.3rem;
+  --font-size-s: 1.1rem;
+  --font-size-xs: 0.9rem;
+  --font-size-mm: 1.5rem;
 }
 
 body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,7 @@
 }
 
 @font-face {
-  font-family: 'Permanentmarker';
+  font-family: 'Permanent Marker';
   src: url('./assets/fonts/PermanentMarker-Regular.tff');
   font-weight: 400;
 }
@@ -35,7 +35,7 @@
   --color-day-highlight: #ffda7a;
   --color-division-line: #ce8dcc;
   --font-family-primary: 'Lato', sans-serif;
-  --font-family-secondary: 'Permanentmarker', cursive;
+  --font-family-secondary: 'Permanent Marker', cursive;
   --font-weight-regular: 400;
   --font-weight-light: 300;
   --font-size-xl: 2.5rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,7 +38,7 @@
   --font-family-secondary: 'Permanent Marker', cursive;
   --font-weight-regular: 400;
   --font-weight-light: 300;
-  --font-size-xl: 2.5rem;
+  --font-size-xl: 2.3rem;
   --font-size-l: 2rem;
   --font-size-m: 1.3rem;
   --font-size-s: 1.1rem;


### PR DESCRIPTION
- resolves issue #7 

### Questions:

1. I want to remove the dotted underline below Mo, Di, Mi,... but text-decoration: none doesn't seem to work. Not sure how to solve this. (line 56)
2. I used !important to overwrite a flex box to use grid instead. flex box was defined as inline style. Is there another way to overwrite this without using !important ? (line 10)

Current style (without the background color):
![image](https://user-images.githubusercontent.com/87307543/133259108-62ef5775-45cf-41dc-a4d1-8a9cc4f79157.png)


Style from Figma:
![image](https://user-images.githubusercontent.com/87307543/133258933-cb5b2f5b-160f-4d74-886e-bc6eeeae539d.png)

