### PR TITLE
✏️  Fix typo to render correct font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,7 @@
 
 @font-face {
   font-family: 'Permanent Marker';
-  src: url('./assets/fonts/PermanentMarker-Regular.tff');
+  src: url('./assets/fonts/PermanentMarker-Regular.ttf');
   font-weight: 400;
 }
 


### PR DESCRIPTION
The font Permanent Marker was rendered incorrectly because the file name had a typo. It should be **.ttf** (not .tff)